### PR TITLE
Fix Windows/MinGW Portability Issues

### DIFF
--- a/src/core/data_parsing_hub.cpp
+++ b/src/core/data_parsing_hub.cpp
@@ -154,12 +154,19 @@ void verify_resource_bounds() {
     }
 }
 
+#ifndef _WIN32
 #include <sys/resource.h>
+#endif
+
 void audit_memory_usage() {
+#ifndef _WIN32
     struct rusage usage;
     if (getrusage(RUSAGE_SELF, &usage) == 0) {
         std::cout << "[AUDIT] Max RSS: " << usage.ru_maxrss << " KB" << std::endl;
     }
+#else
+    // audit_memory_usage is not implemented on Windows.
+#endif
 }
 
 } // namespace cerebra

--- a/src/visualization/video_logic.cpp
+++ b/src/visualization/video_logic.cpp
@@ -8,8 +8,11 @@
 #include <cmath>
 #include <random>
 #include <algorithm>
+#ifndef _WIN32
 #include <sys/ioctl.h>
 #include <unistd.h>
+#endif
+#include "ui/terminal_renderer.h"
 
 static const char* INTENSITY_CHARS = " .:+X@";
 static const char* BINARY_CHARS = "01";
@@ -74,8 +77,8 @@ void renderRegion(std::ostringstream& oss, const cerebra::RegionState& region, i
     for (int i = 0; i < depth; ++i) oss << "  ";
     oss << "[" << region.region << "] ";
     if (config.enable_color) oss << intensityToColor(region.intensity, config.theme);
-    struct winsize w; int max_width = 20;
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0) max_width = std::max(10, w.ws_col / 4);
+    int max_width = cerebra::terminal_size().cols / 4;
+    if (max_width < 10) max_width = 10;
     int barWidth = static_cast<int>(region.intensity * max_width);
     for (int i = 0; i < barWidth; ++i) oss << intensityToSymbol(region.intensity, config.intensity_map);
     if (config.enable_color) oss << "\033[0m";

--- a/src/visualization/view_3d.cpp
+++ b/src/visualization/view_3d.cpp
@@ -3,6 +3,9 @@
 #include "ui/terminal_renderer.h"
 
 #include <cmath>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #include <sstream>
 #include <vector>
 #include <unordered_map>


### PR DESCRIPTION
This submission addresses several compilation errors encountered when building QuantaCerebra on Windows with MinGW. 

Key changes include:
1. Conditional compilation blocks (#ifndef _WIN32) for POSIX-only headers and functions in `data_parsing_hub.cpp` and `video_logic.cpp`.
2. Integration of existing `terminal_size` utility in `video_logic.cpp` to remove the dependency on `ioctl` for terminal width detection.
3. Addition of a standard-compliant fallback for `M_PI` in `view_3d.cpp`.

These changes ensure the codebase remains portable and buildable on both POSIX and Windows environments while strictly adhering to the project's zero-dependency architecture.

---
*PR created automatically by Jules for task [17654554862685074688](https://jules.google.com/task/17654554862685074688) started by @drtamarojgreen*